### PR TITLE
Changes to database

### DIFF
--- a/api/data.js
+++ b/api/data.js
@@ -37,6 +37,7 @@ const get_competitors = n => collection(n)(i => ({
   "organization_id" : randomId(ORGANIZATIONS),
   "password" : uuidV1(),
   "registered" : randomBool(),
+  "lead_number" : randomInt(0, 100),
 }))
 
 // So its not completley RNG

--- a/api/data.js
+++ b/api/data.js
@@ -34,7 +34,6 @@ const get_competitors = n => collection(n)(i => ({
   "last_name" : randomData().lastName,
   "email" :  randomData().emailAddress,
   "mailing_address" : randomData().street,
-  "lead_number" : randomBool() ? randomInt(0, 100) : null,
   "organization_id" : randomId(ORGANIZATIONS),
   "password" : uuidV1(),
   "registered" : randomBool(),
@@ -66,6 +65,7 @@ const get_competitions = n => collection(n)(i => ({
   "RegEndDate" : randomDate({year: 2017}),
   "EarlyRegDeadline" : randomDate({year: 2017}),
   "RegularRegDeadline" : randomDate({year: 2017}),
+  "CompAdmin" : randomData().emailAddress,
 }))
 
 
@@ -84,14 +84,23 @@ const get_rounds = n => collection(n)(i => ({
   "order_number" : i,
   "size" : randomInt(50, 100),
   "next_round" : randomInt(0, 20),
+  "judge_1" : randomId(JUDGES),
+  "judge_2" : randomId(JUDGES),
+  "judge_3" : randomId(JUDGES),
+  "judge_4" : randomId(JUDGES),
+  "judge_5" : randomId(JUDGES),
+  "judge_6" : randomBool() ? randomId(JUDGES) : null,
 }))
 
 const get_partnerships = n => collection(n)(i => ({
+  "lead_number" : randomInt(0, 100),
   "Lead Competitor id" : randomId(COMPETITORS),
   "Follow Competitor id" : randomId(COMPETITORS),
   "Event Category" : randomId(EVENTS),
   "Lead Confirmed" : randomBool(),
   "Follow Confirmed" : randomBool(),
+  "Called Back" : randomBool(),
+  "Timestamp" : randomDate({year: 2017}),
 }))
 
 const get_organizations = n => collection(n)(i => ({
@@ -109,8 +118,7 @@ const get_judges = n => collection(n)(i => ({
   "Email address" : randomData(1).emailAddress,
   "Token" : uuidV1(),
   "First Name" : randomData().firstName,
-  "Last Name" : randomData().lastName,
-  "Current event id" : randomId(EVENTS)
+  "Last Name" : randomData().lastName,  
 }))
 
 const get_payment_records = n => collection(n)(i => ({
@@ -124,7 +132,7 @@ const get_payment_records = n => collection(n)(i => ({
 }))
 
 const get_schedule = n => collection(n) (i => ({
-  "id" : i,
+  "id" : i, 
   "order_number" : i,
   "title" : pg.generate(),
   "style" : pg.generate(),

--- a/api/data.js
+++ b/api/data.js
@@ -44,9 +44,9 @@ const get_callbacks = competitors => competitors
 .filter(c => c["Lead Number"])
 .map((c, i) => ({
   "id" : i,
-  "timestamp" : randomDate({year: 2017}),
+  "timestamp" : randomDate({year: 2017}).toDateString(),
   "judge_id" : randomId(JUDGES),
-  "Lead Competitor number" : c["Lead Number"],
+  "Lead Competitor number" : c["Lead Number"s],
   "round_id" : randomId(ROUNDS),
 }))
 
@@ -59,13 +59,14 @@ const get_competitions = n => collection(n)(i => ({
   "EarlyPrice" : randomInt(0, 100),
   "RegPrice" : randomInt(0, 100),
   "LatePrice" : randomInt(0, 100),
-  "StartDate" : randomDate({year: 2018}),
-  "EndDate" : randomDate({year: 2018}),
-  "RegStartDate" : randomDate({year: 2017}),
-  "RegEndDate" : randomDate({year: 2017}),
-  "EarlyRegDeadline" : randomDate({year: 2017}),
-  "RegularRegDeadline" : randomDate({year: 2017}),
+  "StartDate" : randomDate({year: 2018}).toDateString(),
+  "EndDate" : randomDate({year: 2018}).toDateString(),
+  "RegStartDate" : randomDate({year: 2017}).toDateString(),
+  "RegEndDate" : randomDate({year: 2017}).toDateString(),
+  "EarlyRegDeadline" : (randomDate({year: 2017})).toDateString(),
+  "RegularRegDeadline" : randomDate({year: 2017}).toDateString(),
   "CompAdmin" : randomData().emailAddress,
+
 }))
 
 
@@ -124,7 +125,7 @@ const get_judges = n => collection(n)(i => ({
 const get_payment_records = n => collection(n)(i => ({
   "id" : i,
   "competitionId" : randomId(COMPETITIONS),
-  "Timestamp" : randomDate({year: 2017}),
+  "Timestamp" : randomDate({year: 2017}).toDateString(),
   "Competitor id" : randomId(COMPETITORS),
   "Amount" : randomInt(50, 100)/2,
   "Online/offline" : randomBool(),


### PR DESCRIPTION
MAIN CHANGE:

Lead number is now per partnership rather than per competitor.

This updates the RNG data to the current (and hopefully final) database scheme